### PR TITLE
Fix broken repository link in crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.70"
 
 description = "Hides the boilerplate code needed with std::sync::Condvar"
 readme = true
-repository = "https://github.com/emabee/cond_sync"
+repository = "https://github.com/emabee/rust-cond_sync"
 license = "MIT OR Apache-2.0"
 keywords = ["concurrency", "synchronization"]
 categories = ["concurrency"]


### PR DESCRIPTION
The published crate (https://crates.io/crates/cond_sync) links to https://github.com/emabee/cond_sync, but that repository does not exist. This PR adjusts the link to point to https://github.com/emabee/rust-cond_sync instead.